### PR TITLE
hotfix: Supabase 타입 생성 경로 수정

### DIFF
--- a/.github/workflows/refresh-supabase-types.yml
+++ b/.github/workflows/refresh-supabase-types.yml
@@ -30,7 +30,9 @@ jobs:
         run: npm ci
 
       - name: Generate types
-        run: npx supabase gen types typescript --project-id "$SUPABASE_PROJECT_REF" > src/types/database.types.ts
+        run: |
+          mkdir -p src/shared/types
+          npx supabase gen types typescript --project-id "$SUPABASE_PROJECT_REF" > src/shared/types/database.types.ts
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
## Background
GitHub Actions에서 Supabase 타입 생성 시 출력 경로가 실제 프로젝트 구조와 달라 다음 에러가 발생했습니다.

```
src/types/database.types.ts: No such file or directory
```

## 변경 사항
- `refresh-supabase-types.yml`의 타입 생성 출력 경로를 `src/shared/types/database.types.ts`로 수정
- `mkdir -p src/shared/types`를 추가해 디렉터리 부재로 인한 리다이렉션 실패 방지
