### PR TITLE
포스트 description·authoring_mode 스키마 전환

### DIFF
--- a/src/entities/comment/api/comment.service.test.ts
+++ b/src/entities/comment/api/comment.service.test.ts
@@ -195,8 +195,10 @@ function createFakeAdapter() {
         id: 10,
         user_id: "user-1",
         content: "post",
+        description: "post summary",
         code: null,
         language: null,
+        authoring_mode: "hand_written",
         created_at: "2026-03-12T00:00:00.000Z",
         updated_at: null,
         deleted_at: null,
@@ -204,7 +206,6 @@ function createFakeAdapter() {
         like_count: 0,
         bookmark_count: 0,
         view_count: 0,
-        is_review_enabled: true,
       },
     ],
   );

--- a/src/entities/post/api/post.action.test.ts
+++ b/src/entities/post/api/post.action.test.ts
@@ -6,6 +6,7 @@ const {
   getCurrentUserAuthMock,
   getPostByIdMock,
   getReviewCommentsCountMock,
+  hasUserPostedOnLocalDayMock,
   revalidatePathMock,
   updatePostMock,
 } = vi.hoisted(() => ({
@@ -14,6 +15,7 @@ const {
   createPostMock: vi.fn(),
   getPostByIdMock: vi.fn(),
   getReviewCommentsCountMock: vi.fn(),
+  hasUserPostedOnLocalDayMock: vi.fn(),
   updatePostMock: vi.fn(),
   deletePostMock: vi.fn(),
 }));
@@ -30,6 +32,7 @@ vi.mock("@/entities/post/api/post.service", () => ({
   createPost: createPostMock,
   getPostById: getPostByIdMock,
   getReviewCommentsCount: getReviewCommentsCountMock,
+  hasUserPostedOnLocalDay: hasUserPostedOnLocalDayMock,
   updatePost: updatePostMock,
   deletePost: deletePostMock,
 }));
@@ -39,6 +42,10 @@ import { createPostAction, updatePostAction } from "./post.action";
 describe("post.action", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    hasUserPostedOnLocalDayMock.mockResolvedValue({
+      data: false,
+      error: null,
+    });
   });
 
   it("createPostAction은 서버 세션 유저를 author로 강제한다", async () => {
@@ -64,19 +71,69 @@ describe("post.action", () => {
         bio: "",
       },
       content: "content",
+      description: "description",
       code: "const a = 1;",
       language: "typescript",
+      authoring_mode: "hand_written",
       tags: ["ts"],
-      is_review_enabled: true,
+      localDayContext: {
+        dayKey: "2026-03-25",
+        dayStartAt: "2026-03-24T15:00:00.000Z",
+        dayEndAt: "2026-03-25T14:59:59.999Z",
+        timezoneOffsetMinutes: -540,
+      },
     });
 
     expect(result.error).toBeNull();
+    expect(hasUserPostedOnLocalDayMock).toHaveBeenCalledWith({
+      dayKey: "2026-03-25",
+      dayStartAt: "2026-03-24T15:00:00.000Z",
+      dayEndAt: "2026-03-25T14:59:59.999Z",
+      timezoneOffsetMinutes: -540,
+      userId: "server-user",
+    });
     expect(createPostMock).toHaveBeenCalledWith(
       expect.objectContaining({
         author: user,
       }),
     );
     expect(revalidatePathMock).toHaveBeenCalledWith("/home");
+  });
+
+  it("createPostAction은 오늘 이미 작성한 경우 생성을 차단한다", async () => {
+    getCurrentUserAuthMock.mockResolvedValue({
+      id: "server-user",
+      username: "server_user",
+    });
+    hasUserPostedOnLocalDayMock.mockResolvedValue({
+      data: true,
+      error: null,
+    });
+
+    const result = await createPostAction({
+      author: {
+        id: "client-user",
+        username: "client_user",
+        nickname: "Client User",
+        avatar: "",
+        bio: "",
+      },
+      content: "content",
+      description: "description",
+      code: null,
+      language: null,
+      authoring_mode: "hand_written",
+      tags: [],
+      localDayContext: {
+        dayKey: "2026-03-25",
+        dayStartAt: "2026-03-24T15:00:00.000Z",
+        dayEndAt: "2026-03-25T14:59:59.999Z",
+        timezoneOffsetMinutes: -540,
+      },
+    });
+
+    expect(result).toEqual({ error: "오늘은 이미 글을 작성했습니다." });
+    expect(createPostMock).not.toHaveBeenCalled();
   });
 
   it("updatePostAction은 타인 포스트 수정을 차단한다", async () => {
@@ -99,7 +156,7 @@ describe("post.action", () => {
     expect(updatePostMock).not.toHaveBeenCalled();
   });
 
-  it("리뷰 댓글이 존재하면 코드 수정을 차단한다", async () => {
+  it("인라인 코멘트가 존재하면 코드 수정을 차단한다", async () => {
     getCurrentUserAuthMock.mockResolvedValue({
       id: "me",
       username: "me",
@@ -120,7 +177,7 @@ describe("post.action", () => {
     const result = await updatePostAction(1, { code: "changed" });
 
     expect(result).toEqual({
-      error: "코드 리뷰가 존재하는 포스트는 코드를 수정할 수 없습니다.",
+      error: "인라인 코멘트가 존재하는 포스트는 코드를 수정할 수 없습니다.",
     });
     expect(updatePostMock).not.toHaveBeenCalled();
   });

--- a/src/entities/post/api/post.action.ts
+++ b/src/entities/post/api/post.action.ts
@@ -8,19 +8,43 @@ import {
   deletePost,
   getPostById,
   getReviewCommentsCount,
+  hasUserPostedOnLocalDay,
   updatePost,
 } from "@/entities/post/api/post.service";
+import { type LocalDayContext } from "@/shared/lib/date";
 import { getCurrentUserAuth } from "@/shared/lib/supabase/current-user";
 
-async function createPostAction(data: CreatePostDTO) {
+type CreatePostActionInput = CreatePostDTO & {
+  localDayContext: LocalDayContext;
+};
+
+async function createPostAction(data: CreatePostActionInput) {
   const user = await getCurrentUserAuth();
 
   if (!user) {
     return { error: "로그인이 필요합니다." };
   }
 
+  const { localDayContext, ...postData } = data;
+  const { data: hasPostedToday, error: hasPostedError } =
+    await hasUserPostedOnLocalDay({
+      ...localDayContext,
+      userId: user.id,
+    });
+
+  if (hasPostedError) {
+    console.error(hasPostedError);
+    return {
+      error: hasPostedError.message || "오늘 작성 여부 확인에 실패했습니다.",
+    };
+  }
+
+  if (hasPostedToday) {
+    return { error: "오늘은 이미 글을 작성했습니다." };
+  }
+
   // 데이터의 author는 클라이언트에서 오므로, 서버의 신뢰할 수 있는 user 정보로 덮어씌웁니다.
-  const secureData = { ...data, author: user };
+  const secureData = { ...postData, author: user };
 
   const { data: newPost, error } = await createPost(secureData);
 
@@ -61,7 +85,7 @@ async function updatePostAction(id: number, data: Partial<CreatePostDTO>) {
 
     if (count && count > 0) {
       return {
-        error: "코드 리뷰가 존재하는 포스트는 코드를 수정할 수 없습니다.",
+        error: "인라인 코멘트가 존재하는 포스트는 코드를 수정할 수 없습니다.",
       };
     }
   }

--- a/src/entities/post/api/post.interface.ts
+++ b/src/entities/post/api/post.interface.ts
@@ -5,5 +5,11 @@ import { Post } from "@/shared/types/types";
  */
 export type CreatePostDTO = Pick<
   Post,
-  "author" | "content" | "code" | "language" | "tags" | "is_review_enabled"
+  | "author"
+  | "content"
+  | "description"
+  | "code"
+  | "language"
+  | "authoring_mode"
+  | "tags"
 >;

--- a/src/entities/post/api/post.service.test.ts
+++ b/src/entities/post/api/post.service.test.ts
@@ -40,7 +40,6 @@ describe("post.service", () => {
     });
 
     await getPosts({
-      isReviewEnabled: true,
       authorId: "author-1",
       likedByUserId: "liked-user",
       bookmarkedByUserId: "bookmark-user",
@@ -59,11 +58,10 @@ describe("post.service", () => {
           { column: "post_likes.user_id", value: "liked-user" },
           { column: "bookmarks.user_id", value: "bookmark-user" },
           { column: "filter_tags.tags.name", value: "typescript" },
-          { column: "is_review_enabled", value: true },
           { column: "user_id", value: "author-1" },
         ]),
         range: { from: 0, to: 2 },
-        or: "content.ilike.%a b\\_\\% test%,code.ilike.%a b\\_\\% test%",
+        or: "description.ilike.%a b\\_\\% test%,content.ilike.%a b\\_\\% test%,code.ilike.%a b\\_\\% test%",
       }),
     );
   });
@@ -100,9 +98,10 @@ describe("post.service", () => {
 
     const result = await updatePost(99, {
       content: "updated",
+      description: "summary",
       code: "const x = 1;",
       language: "typescript",
-      is_review_enabled: true,
+      authoring_mode: "ai_assisted",
       tags: ["ts", "vitest"],
     });
 
@@ -110,9 +109,10 @@ describe("post.service", () => {
       p_post_id: 99,
       post_data: {
         content: "updated",
+        description: "summary",
         code: "const x = 1;",
         language: "typescript",
-        is_review_enabled: true,
+        authoring_mode: "ai_assisted",
       },
       tags: ["ts", "vitest"],
     });

--- a/src/entities/post/api/post.service.ts
+++ b/src/entities/post/api/post.service.ts
@@ -4,7 +4,7 @@ import {
   isValidLocalDayContext,
   type LocalDayContext,
 } from "@/shared/lib/date";
-import { Database, Tables } from "@/shared/types/database.types";
+import { Tables } from "@/shared/types/database.types";
 import { Post } from "@/shared/types/types";
 
 import { CreatePostDTO } from "./post.interface";
@@ -22,6 +22,15 @@ type LocalDayListQueryOptions = LocalDayContext & {
   followingIds?: string[];
   offset?: number;
   limit?: number;
+};
+
+type PostMutationPayload = {
+  content: string;
+  description: string;
+  code: string | null;
+  language: string | null;
+  user_id?: string;
+  authoring_mode: Post["authoring_mode"];
 };
 
 function sanitizeKeywordForOrFilter(rawKeyword: string): string {
@@ -87,14 +96,14 @@ export async function createPost(
   data: CreatePostDTO,
 ): Promise<{ data: Post | null; error: Error | null }> {
   const db = getDatabaseAdapter();
-  const postData: Database["public"]["Functions"]["create_post_with_tags"]["Args"]["post_data"] =
-    {
-      content: data.content,
-      code: data.code,
-      language: data.language,
-      user_id: data.author.id,
-      is_review_enabled: data.is_review_enabled,
-    };
+  const postData: PostMutationPayload = {
+    content: data.content,
+    description: data.description,
+    code: data.code,
+    language: data.language,
+    user_id: data.author.id,
+    authoring_mode: data.authoring_mode,
+  };
 
   const { data: insertedPost, error } = await db.rpc<Tables<"posts">>(
     "create_post_with_tags",
@@ -118,7 +127,6 @@ export async function createPost(
 }
 
 export async function getPosts({
-  isReviewEnabled = false,
   authorId,
   likedByUserId,
   bookmarkedByUserId,
@@ -127,7 +135,6 @@ export async function getPosts({
   offset,
   limit,
 }: {
-  isReviewEnabled?: boolean;
   authorId?: string;
   likedByUserId?: string;
   bookmarkedByUserId?: string;
@@ -167,10 +174,6 @@ export async function getPosts({
     filters.push({ column: "filter_tags.tags.name", value: tag });
   }
 
-  if (isReviewEnabled) {
-    filters.push({ column: "is_review_enabled", value: true });
-  }
-
   if (authorId) {
     filters.push({ column: "user_id", value: authorId });
   }
@@ -187,7 +190,7 @@ export async function getPosts({
     select: selectString,
     filters,
     or: escapedKeyword
-      ? `content.ilike.%${escapedKeyword}%,code.ilike.%${escapedKeyword}%`
+      ? `description.ilike.%${escapedKeyword}%,content.ilike.%${escapedKeyword}%,code.ilike.%${escapedKeyword}%`
       : undefined,
     orderBy: { column: "created_at", ascending: false },
     range:
@@ -435,13 +438,13 @@ export async function updatePost(
 ): Promise<{ data: Post | null; error: Error | null }> {
   const db = getDatabaseAdapter();
   const { tags, ...postFields } = data;
-  const postData: Database["public"]["Functions"]["update_post_with_tags"]["Args"]["post_data"] =
-    {
-      content: postFields.content,
-      code: postFields.code,
-      language: postFields.language,
-      is_review_enabled: postFields.is_review_enabled,
-    };
+  const postData: Partial<PostMutationPayload> = {
+    content: postFields.content,
+    description: postFields.description,
+    code: postFields.code,
+    language: postFields.language,
+    authoring_mode: postFields.authoring_mode,
+  };
 
   const { error } = await db.rpc<unknown>("update_post_with_tags", {
     p_post_id: id,

--- a/src/features/post-interaction/model/index.ts
+++ b/src/features/post-interaction/model/index.ts
@@ -1,1 +1,1 @@
-export { type PostFormData,postSchema } from "./post.schema";
+export { type PostFormData, postSchema } from "./post.schema";

--- a/src/features/post-interaction/model/post.schema.ts
+++ b/src/features/post-interaction/model/post.schema.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 
 export const postSchema = z.object({
+  description: z
+    .string()
+    .trim()
+    .min(1, "짧은 설명을 입력해주세요.")
+    .max(200, "짧은 설명은 200자 이하여야 합니다."),
   content: z
     .string()
     .trim()
@@ -8,7 +13,6 @@ export const postSchema = z.object({
     .max(5000, "게시글은 5000자 이하여야 합니다."),
   code: z.string().nullable(),
   language: z.string().nullable(),
-  isReviewEnabled: z.boolean(),
 });
 
 export type PostFormData = z.infer<typeof postSchema>;

--- a/src/features/post-interaction/ui/post-dialog.tsx
+++ b/src/features/post-interaction/ui/post-dialog.tsx
@@ -1,21 +1,24 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import dynamic from "next/dynamic";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Code2, Info, Loader, Plus, Send } from "lucide-react";
+import { Code2, Loader, Plus, Send } from "lucide-react";
 
 import { createPostAction, updatePostAction } from "@/entities/post";
 import { useAuth, UserAvatar } from "@/entities/user";
+import { getCurrentLocalDayContext } from "@/shared/lib/date";
 import { handleAction } from "@/shared/lib/handle-action";
-import { captureEvent } from "@/shared/lib/posthog";
+import {
+  captureEvent,
+  getTodayExperimentProperties,
+} from "@/shared/lib/posthog";
 import { POST_LIST_QUERY_KEY } from "@/shared/lib/query/post-list-query";
 import { Post } from "@/shared/types/types";
 import { Button } from "@/shared/ui/button";
-import { Checkbox } from "@/shared/ui/checkbox";
 import { Dialog, DialogContent, DialogTitle } from "@/shared/ui/dialog";
 import { Skeleton } from "@/shared/ui/skeleton";
 
@@ -30,25 +33,36 @@ import { Input } from "@/shared/ui/input";
 import { Label } from "@/shared/ui/label";
 import { TagList } from "@/shared/ui/tag-list";
 import { Textarea } from "@/shared/ui/textarea";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
-import { type PostFormData,postSchema } from "../model";
+import { type PostFormData, postSchema } from "../model";
 
 interface PostDialogProps {
   isOpen: boolean;
   handleClose: () => void;
   post?: Post;
+  openedAtMs?: number | null;
   source?: string;
+}
+
+function getElapsedTimeMs(startedAt: number | null) {
+  if (startedAt === null) {
+    return null;
+  }
+
+  return Math.round(performance.now() - startedAt);
 }
 
 export default function PostDialog({
   isOpen,
   handleClose,
+  openedAtMs = null,
   post,
   source = "create_post_widget",
 }: PostDialogProps) {
   const { user } = useAuth();
   const queryClient = useQueryClient();
+  const localDayContext = useMemo(() => getCurrentLocalDayContext(), []);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
 
   const {
     register,
@@ -60,23 +74,21 @@ export default function PostDialog({
   } = useForm<PostFormData>({
     resolver: zodResolver(postSchema),
     defaultValues: {
+      description: post?.description || "",
       content: post?.content || "",
       code: post?.code || null,
       language: post?.language || "text",
-      isReviewEnabled: post?.is_review_enabled || false,
     },
   });
 
-  const [snippetMode, setSnippetMode] = useState(!!post?.code);
+  const [snippetMode, setSnippetMode] = useState(Boolean(post?.code));
   const [tags, setTags] = useState<string[]>(post?.tags || []);
   const [tagInput, setTagInput] = useState("");
 
+  const descriptionValue = useWatch({ control, name: "description" });
+  const contentValue = useWatch({ control, name: "content" });
   const codeValue = useWatch({ control, name: "code" });
   const languageValue = useWatch({ control, name: "language" });
-  const isReviewEnabledValue = useWatch({
-    control,
-    name: "isReviewEnabled",
-  });
 
   const toggleSnippetMode = () => {
     captureEvent("post_snippet_mode_toggled", {
@@ -121,17 +133,19 @@ export default function PostDialog({
 
   const savePostMutation = useMutation({
     mutationFn: async (commonData: {
+      description: string;
       content: string;
       code: string | null;
       language: string | null;
       tags: string[];
-      is_review_enabled: boolean;
+      authoring_mode: Post["authoring_mode"];
     }) => {
       const action = post
         ? updatePostAction(post.id, commonData)
         : createPostAction({
             author: user!,
             ...commonData,
+            localDayContext,
           });
 
       return handleAction(action, {
@@ -147,8 +161,14 @@ export default function PostDialog({
       }
 
       captureEvent(post ? "post_updated" : "post_created", {
+        authoring_mode: commonData.authoring_mode,
+        content_length: commonData.content.length,
+        description_length: commonData.description.length,
         has_code: Boolean(commonData.code),
         tag_count: commonData.tags.length,
+        time_to_submit_ms: getElapsedTimeMs(openedAtMs),
+        source,
+        ...getTodayExperimentProperties(),
       });
 
       handleClose();
@@ -162,33 +182,83 @@ export default function PostDialog({
   const onSubmit = async (data: PostFormData) => {
     if (!user) return;
 
+    setHasSubmitted(true);
+    const timeToSubmitMs = getElapsedTimeMs(openedAtMs);
+
     const commonData = {
+      description: data.description,
       content: data.content,
       code: snippetMode ? data.code : null,
       language: snippetMode ? data.language : null,
+      authoring_mode: post?.authoring_mode ?? "hand_written",
       tags,
-      is_review_enabled: data.isReviewEnabled,
     };
 
     captureEvent(post ? "post_update_submitted" : "post_create_submitted", {
+      authoring_mode: commonData.authoring_mode,
+      content_length: commonData.content.length,
+      description_length: commonData.description.length,
       has_code: Boolean(commonData.code),
       tag_count: tags.length,
-      review_enabled: commonData.is_review_enabled,
+      time_to_submit_ms: timeToSubmitMs,
       source,
+      ...getTodayExperimentProperties(),
     });
 
     await savePostMutation.mutateAsync(commonData);
   };
 
+  const handleDialogChange = (nextOpen: boolean) => {
+    if (!nextOpen && !hasSubmitted) {
+      captureEvent("post_dialog_closed", {
+        had_input: Boolean(
+          descriptionValue?.trim() ||
+            contentValue?.trim() ||
+            codeValue?.trim() ||
+            tagInput.trim() ||
+            tags.length > 0,
+        ),
+        source,
+        ...getTodayExperimentProperties(),
+      });
+    }
+
+    if (!nextOpen) {
+      handleClose();
+    }
+  };
+
   return (
-    <Dialog open={isOpen} onOpenChange={handleClose}>
+    <Dialog open={isOpen} onOpenChange={handleDialogChange}>
       <DialogContent>
         <DialogTitle>{post ? "게시글 수정" : "새 게시글 작성"}</DialogTitle>
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="flex gap-2">
             {user && <UserAvatar user={user} />}
             <div className="flex flex-col gap-2 w-full">
-              <Textarea className="resize-none" {...register("content")} />
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="description">짧은 설명</Label>
+                <Textarea
+                  id="description"
+                  className="resize-none min-h-20"
+                  placeholder="피드에서 먼저 보일 한 줄 요약을 적어주세요."
+                  {...register("description")}
+                />
+                {errors.description && (
+                  <p className="text-sm text-destructive">
+                    {errors.description.message}
+                  </p>
+                )}
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="content">본문</Label>
+                <Textarea
+                  id="content"
+                  className="resize-none"
+                  placeholder="오늘 배운 내용이나 맥락을 자세히 남겨보세요."
+                  {...register("content")}
+                />
+              </div>
               {errors.content && (
                 <p className="text-sm text-destructive">
                   {errors.content.message}
@@ -210,25 +280,8 @@ export default function PostDialog({
                     setCode={(code) => setValue("code", code)}
                     setLanguage={(lang) => setValue("language", lang)}
                   />
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      id="is_review_enabled"
-                      checked={isReviewEnabledValue ?? false}
-                      onCheckedChange={(checked) =>
-                        setValue("isReviewEnabled", checked === true)
-                      }
-                    />
-                    <Label htmlFor="is_review_enabled">코드 리뷰 허용</Label>
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <Info className="w-4 h-4" />
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>
-                          허용 시 코드 라인 별로 리뷰 코멘트를 받을 수 있습니다.
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
+                  <div className="rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground">
+                    코드 스니펫이 있으면 누구나 라인별 인라인 코멘트를 남길 수 있습니다.
                   </div>
                 </>
               )}

--- a/src/features/post-interaction/ui/post-menu.tsx
+++ b/src/features/post-interaction/ui/post-menu.tsx
@@ -28,6 +28,7 @@ export default function PostMenu({ post }: PostMenuProps) {
   const { user } = useAuth();
   const queryClient = useQueryClient();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [dialogOpenedAtMs, setDialogOpenedAtMs] = useState<number | null>(null);
   const deletePostMutation = useMutation({
     mutationFn: () =>
       handleAction(deletePostAction(post.id), {
@@ -65,7 +66,11 @@ export default function PostMenu({ post }: PostMenuProps) {
           disabled={!isOwner}
           onSelect={(e) => {
             e.preventDefault();
+            setDialogOpenedAtMs(performance.now());
             captureEvent("post_edit_clicked", { post_id: post.id });
+            captureEvent("post_dialog_opened", {
+              source: "post_edit_menu",
+            });
             setIsDialogOpen(true);
           }}
         >
@@ -85,7 +90,9 @@ export default function PostMenu({ post }: PostMenuProps) {
         <PostDialog
           isOpen={isDialogOpen}
           handleClose={() => setIsDialogOpen(false)}
+          openedAtMs={dialogOpenedAtMs}
           post={post}
+          source="post_edit_menu"
         />
       )}
     </DropdownMenu>

--- a/src/features/post-list/api/post-list.action.ts
+++ b/src/features/post-list/api/post-list.action.ts
@@ -17,7 +17,6 @@ const DEFAULT_POST_LIST_PAGE_SIZE = 10;
 const MAX_POST_LIST_PAGE_SIZE = 50;
 
 type PostListFilterOptions = {
-  isReviewEnabled?: boolean;
   authorId?: string;
   likedByUserId?: string;
   bookmarkedByUserId?: string;

--- a/src/pages/home/ui/today-section.tsx
+++ b/src/pages/home/ui/today-section.tsx
@@ -6,19 +6,19 @@ import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, CalendarDays, Loader2, LockKeyhole } from "lucide-react";
 
+import { PostCard } from "@/widgets/post-card";
 import { PostDialog } from "@/features/post-interaction";
 import {
   getTodayPostListAction,
   hasUserPostedTodayAction,
 } from "@/features/post-list";
-import { captureEvent, getTodayExperimentProperties, getTodayGateState } from "@/shared/lib/posthog";
 import { getCurrentLocalDayContext } from "@/shared/lib/date";
+import { captureEvent, getTodayExperimentProperties, getTodayGateState } from "@/shared/lib/posthog";
 import { POST_LIST_QUERY_KEY } from "@/shared/lib/query/post-list-query";
 import { Button } from "@/shared/ui/button";
 import { Card, CardContent } from "@/shared/ui/card";
 import { Skeleton } from "@/shared/ui/skeleton";
 import { VerticalMarquee } from "@/shared/ui/vertical-marquee";
-import { PostCard } from "@/widgets/post-card";
 
 function TodaySkeleton() {
   return <Skeleton className="h-52 rounded-3xl" />;

--- a/src/pages/home/ui/today-section.tsx
+++ b/src/pages/home/ui/today-section.tsx
@@ -1,33 +1,35 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, CalendarDays, Loader2, LockKeyhole } from "lucide-react";
 
-import { PostCard } from "@/widgets/post-card";
 import { PostDialog } from "@/features/post-interaction";
 import {
   getTodayPostListAction,
   hasUserPostedTodayAction,
 } from "@/features/post-list";
+import { captureEvent, getTodayExperimentProperties, getTodayGateState } from "@/shared/lib/posthog";
 import { getCurrentLocalDayContext } from "@/shared/lib/date";
 import { POST_LIST_QUERY_KEY } from "@/shared/lib/query/post-list-query";
 import { Button } from "@/shared/ui/button";
 import { Card, CardContent } from "@/shared/ui/card";
 import { Skeleton } from "@/shared/ui/skeleton";
 import { VerticalMarquee } from "@/shared/ui/vertical-marquee";
+import { PostCard } from "@/widgets/post-card";
 
 function TodaySkeleton() {
-  return (
-    <Skeleton className="h-52 rounded-3xl" />
-  );
+  return <Skeleton className="h-52 rounded-3xl" />;
 }
 
 export function TodaySection() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [dialogOpenedAtMs, setDialogOpenedAtMs] = useState<number | null>(null);
   const localDayContext = useMemo(() => getCurrentLocalDayContext(), []);
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const hasCapturedViewRef = useRef(false);
 
   const todayGateQuery = useQuery({
     queryKey: [...POST_LIST_QUERY_KEY, "today", "gate", localDayContext],
@@ -65,13 +67,49 @@ export function TodaySection() {
   const isLoading =
     todayGateQuery.isLoading || (hasPostedToday && todayPostsQuery.isLoading);
   const posts = todayPostsQuery.data ?? [];
+  const gateState = getTodayGateState(hasPostedToday);
+
+  useEffect(() => {
+    if (
+      isLoading ||
+      todayGateQuery.isError ||
+      hasCapturedViewRef.current ||
+      !sectionRef.current
+    ) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries[0]?.isIntersecting || hasCapturedViewRef.current) {
+          return;
+        }
+
+        captureEvent("today_module_viewed", {
+          gate_state: gateState,
+          path: "/home",
+          ...getTodayExperimentProperties(),
+        });
+        hasCapturedViewRef.current = true;
+        observer.disconnect();
+      },
+      { threshold: 0.35 },
+    );
+
+    observer.observe(sectionRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [gateState, isLoading, todayGateQuery.isError]);
 
   return (
-    <section className="space-y-4">
+    <section ref={sectionRef} className="space-y-4">
       {isDialogOpen && (
         <PostDialog
           isOpen={isDialogOpen}
           handleClose={() => setIsDialogOpen(false)}
+          openedAtMs={dialogOpenedAtMs}
           source="today_locked_overlay"
         />
       )}
@@ -87,7 +125,16 @@ export function TodaySection() {
         </div>
 
         <Button asChild variant="ghost" className="rounded-full px-3">
-          <Link href="/today">
+          <Link
+            href="/today"
+            onClick={() => {
+              captureEvent("today_cta_clicked", {
+                gate_state: gateState,
+                source: "today_section_more",
+                ...getTodayExperimentProperties(),
+              });
+            }}
+          >
             더보기
             <ArrowRight className="h-4 w-4" />
           </Link>
@@ -125,7 +172,19 @@ export function TodaySection() {
               <button
                 type="button"
                 className="group max-w-xl cursor-pointer space-y-4 transition-transform duration-200 ease-out hover:scale-[1.035]"
-                onClick={() => setIsDialogOpen(true)}
+                onClick={() => {
+                  captureEvent("today_cta_clicked", {
+                    gate_state: gateState,
+                    source: "today_locked_overlay",
+                    ...getTodayExperimentProperties(),
+                  });
+                  setDialogOpenedAtMs(performance.now());
+                  captureEvent("post_dialog_opened", {
+                    source: "today_locked_overlay",
+                    ...getTodayExperimentProperties(),
+                  });
+                  setIsDialogOpen(true);
+                }}
               >
                 <div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-white/12 bg-white/8 text-white/90 backdrop-blur-sm transition-transform duration-200 ease-out group-hover:scale-105">
                   <LockKeyhole className="h-4 w-4" />

--- a/src/pages/today/ui/today.tsx
+++ b/src/pages/today/ui/today.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 
 import { useQuery } from "@tanstack/react-query";
@@ -12,12 +12,18 @@ import {
   hasUserPostedTodayAction,
 } from "@/features/post-list";
 import { getCurrentLocalDayContext } from "@/shared/lib/date";
+import {
+  captureEvent,
+  getTodayExperimentProperties,
+  getTodayGateState,
+} from "@/shared/lib/posthog";
 import { POST_LIST_QUERY_KEY } from "@/shared/lib/query/post-list-query";
 import { PageHeader } from "@/shared/ui/page-header";
 
 export function TodayPage() {
   const router = useRouter();
   const localDayContext = useMemo(() => getCurrentLocalDayContext(), []);
+  const hasCapturedViewRef = useRef(false);
   const todayGateQuery = useQuery({
     queryKey: [...POST_LIST_QUERY_KEY, "today", "page-gate", localDayContext],
     queryFn: async () => {
@@ -36,6 +42,24 @@ export function TodayPage() {
       router.replace("/home?today=locked");
     }
   }, [router, todayGateQuery.data]);
+
+  useEffect(() => {
+    if (
+      todayGateQuery.isLoading ||
+      todayGateQuery.isError ||
+      todayGateQuery.data !== true ||
+      hasCapturedViewRef.current
+    ) {
+      return;
+    }
+
+    captureEvent("today_module_viewed", {
+      gate_state: getTodayGateState(true),
+      path: "/today",
+      ...getTodayExperimentProperties(),
+    });
+    hasCapturedViewRef.current = true;
+  }, [todayGateQuery.data, todayGateQuery.isError, todayGateQuery.isLoading]);
 
   if (todayGateQuery.data === false) {
     return (

--- a/src/shared/lib/codelog.ts
+++ b/src/shared/lib/codelog.ts
@@ -1,0 +1,6 @@
+import { type Enums } from "@/shared/types";
+
+export const AUTHORING_MODE_LABELS: Record<Enums<"authoring_mode">, string> = {
+  ai_assisted: "AI Assisted",
+  hand_written: "Hand-Written",
+};

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,5 +1,6 @@
 export * from "./auth";
 export * from "./cn";
+export * from "./codelog";
 export * from "./date";
 export * from "./featured-tags";
 export * from "./handle-action";

--- a/src/shared/lib/posthog/client.ts
+++ b/src/shared/lib/posthog/client.ts
@@ -3,6 +3,8 @@ import posthog from "posthog-js";
 type EventProperties = Record<string, string | number | boolean | null | undefined>;
 type SanitizedEventProperties = Record<string, string | number | boolean | null>;
 
+export type TodayGateState = "locked" | "posted_today";
+
 function isPostHogEnabled() {
   return Boolean(process.env.NEXT_PUBLIC_POSTHOG_KEY);
 }
@@ -59,4 +61,16 @@ export function resetPostHogUser() {
   }
 
   posthog.reset();
+}
+
+export function getTodayExperimentProperties() {
+  return {
+    experiment_key:
+      process.env.NEXT_PUBLIC_POSTHOG_TODAY_EXPERIMENT_KEY ?? null,
+    variant: process.env.NEXT_PUBLIC_POSTHOG_TODAY_VARIANT ?? null,
+  };
+}
+
+export function getTodayGateState(hasPostedToday: boolean): TodayGateState {
+  return hasPostedToday ? "posted_today" : "locked";
 }

--- a/src/shared/lib/query/post-list-query.ts
+++ b/src/shared/lib/query/post-list-query.ts
@@ -3,7 +3,6 @@ const POST_LIST_QUERY_ROOT_KEY = "post-list";
 export const POST_LIST_QUERY_KEY = [POST_LIST_QUERY_ROOT_KEY] as const;
 
 type PostListFilterOptions = {
-  isReviewEnabled?: boolean;
   authorId?: string;
   likedByUserId?: string;
   bookmarkedByUserId?: string;
@@ -20,7 +19,6 @@ function normalizePostListFilters(filterOptions: PostListFilterOptions = {}) {
   return {
     authorId: filterOptions.authorId ?? null,
     bookmarkedByUserId: filterOptions.bookmarkedByUserId ?? null,
-    isReviewEnabled: filterOptions.isReviewEnabled ?? null,
     keyword: filterOptions.keyword ?? null,
     likedByUserId: filterOptions.likedByUserId ?? null,
     tag: filterOptions.tag ?? null,
@@ -40,4 +38,3 @@ export function createPostListInfiniteQueryKey({
     },
   ] as const;
 }
-

--- a/src/shared/types/database.types.ts
+++ b/src/shared/types/database.types.ts
@@ -223,14 +223,15 @@ export type Database = {
       }
       posts: {
         Row: {
+          authoring_mode: "hand_written" | "ai_assisted"
           bookmark_count: number
           code: string | null
           comment_count: number
           content: string
           created_at: string
           deleted_at: string | null
+          description: string
           id: number
-          is_review_enabled: boolean
           language: string | null
           like_count: number
           updated_at: string | null
@@ -238,14 +239,15 @@ export type Database = {
           view_count: number
         }
         Insert: {
+          authoring_mode?: "hand_written" | "ai_assisted"
           bookmark_count?: number
           code?: string | null
           comment_count?: number
           content: string
           created_at?: string
           deleted_at?: string | null
+          description: string
           id?: number
-          is_review_enabled?: boolean
           language?: string | null
           like_count?: number
           updated_at?: string | null
@@ -253,14 +255,15 @@ export type Database = {
           view_count?: number
         }
         Update: {
+          authoring_mode?: "hand_written" | "ai_assisted"
           bookmark_count?: number
           code?: string | null
           comment_count?: number
           content?: string
           created_at?: string
           deleted_at?: string | null
+          description?: string
           id?: number
-          is_review_enabled?: boolean
           language?: string | null
           like_count?: number
           updated_at?: string | null
@@ -443,7 +446,7 @@ export type Database = {
       }
     }
     Enums: {
-      [_ in never]: never
+      authoring_mode: "hand_written" | "ai_assisted"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -570,6 +573,8 @@ export type CompositeTypes<
 
 export const Constants = {
   public: {
-    Enums: {},
+    Enums: {
+      authoring_mode: ["hand_written", "ai_assisted"],
+    },
   },
 } as const

--- a/src/shared/types/types.ts
+++ b/src/shared/types/types.ts
@@ -1,4 +1,4 @@
-import { Tables } from "./database.types";
+import { Enums, Tables } from "./database.types";
 
 /**
  * 현재 로그인한 유저를 식별하는 정보를 담는 타입
@@ -29,6 +29,8 @@ export interface Comment extends Omit<Tables<"comments">, "user_id"> {
   author: Author;
   is_liked?: boolean;
 }
+
+export type AuthoringMode = Enums<"authoring_mode">;
 
 /**
  * 사용자 기여도를 담는 타입

--- a/src/widgets/create-post/ui/create-post-form.tsx
+++ b/src/widgets/create-post/ui/create-post-form.tsx
@@ -8,7 +8,10 @@ import { PostDialog } from "@/features/post-interaction";
 import { getTodayPostByUserIdAction } from "@/features/post-list";
 import { useAuth, UserAvatar } from "@/entities/user";
 import { getCurrentLocalDayContext } from "@/shared/lib/date";
-import { captureEvent } from "@/shared/lib/posthog";
+import {
+  captureEvent,
+  getTodayExperimentProperties,
+} from "@/shared/lib/posthog";
 import { POST_LIST_QUERY_KEY } from "@/shared/lib/query/post-list-query";
 import { Button } from "@/shared/ui/button";
 import { Textarea } from "@/shared/ui/textarea";
@@ -20,6 +23,7 @@ import { Textarea } from "@/shared/ui/textarea";
 export default function PostCard() {
   const { user, loading } = useAuth();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [dialogOpenedAtMs, setDialogOpenedAtMs] = useState<number | null>(null);
   const localDayContext = useMemo(() => getCurrentLocalDayContext(), []);
   const todayPostQuery = useQuery({
     queryKey: [...POST_LIST_QUERY_KEY, "today", "mine", user?.id, localDayContext],
@@ -40,7 +44,11 @@ export default function PostCard() {
       | React.FocusEvent<HTMLTextAreaElement>
       | React.MouseEvent<HTMLButtonElement>,
   ) => {
-    captureEvent("post_dialog_opened", { source: "create_post_widget" });
+    setDialogOpenedAtMs(performance.now());
+    captureEvent("post_dialog_opened", {
+      source: "create_post_widget",
+      ...getTodayExperimentProperties(),
+    });
     setIsDialogOpen(true);
     if (e.target instanceof HTMLTextAreaElement) {
       e.target.blur();
@@ -48,7 +56,11 @@ export default function PostCard() {
   };
 
   const openEditDialog = () => {
-    captureEvent("post_dialog_opened", { source: "today_post_edit" });
+    setDialogOpenedAtMs(performance.now());
+    captureEvent("post_dialog_opened", {
+      source: "today_post_edit",
+      ...getTodayExperimentProperties(),
+    });
     setIsDialogOpen(true);
   };
 
@@ -69,6 +81,7 @@ export default function PostCard() {
         <PostDialog
           isOpen={isDialogOpen}
           handleClose={handleCloseDialog}
+          openedAtMs={dialogOpenedAtMs}
           post={todayPost ?? undefined}
           source={todayPost ? "today_post_edit" : "create_post_widget"}
         />

--- a/src/widgets/post-card/ui/post-card.tsx
+++ b/src/widgets/post-card/ui/post-card.tsx
@@ -8,11 +8,10 @@ import { Comment as CommentType, Post as PostType } from "@/shared/types";
 import { Card, CardContent } from "@/shared/ui/card";
 import { TagList } from "@/shared/ui/tag-list";
 
-import { usePostInteraction } from "../lib/use-post-interaction";
-
 import { PostActions } from "./post-actions";
 import { PostCodeSection } from "./post-code-section";
 import { PostHeader } from "./post-header";
+import { usePostInteraction } from "./use-post-interaction";
 
 interface PostCardProps {
   post: PostType;
@@ -25,6 +24,9 @@ export default function PostCard({
   fullPage = false,
   comments,
 }: PostCardProps) {
+  const summary = post.description.trim() || post.content.trim();
+  const shouldShowFullContent =
+    fullPage && post.content.trim() && post.content.trim() !== summary;
   const router = useRouter();
   const {
     isLiked,
@@ -63,13 +65,26 @@ export default function PostCard({
               !fullPage && "hover:cursor-pointer",
             )}
           >
-            {post.content && (
-              <p
-                className="text-foreground whitespace-pre-wrap wrap-break-word leading-relaxed"
+            {summary && (
+              <div
+                className={cn(
+                  "relative rounded-3xl border border-border/70 bg-muted/40 px-4 py-3 text-foreground",
+                  "before:absolute before:-bottom-2 before:left-6 before:h-4 before:w-4 before:rotate-45 before:rounded-sm before:border-b before:border-r before:border-border/70 before:bg-muted/40 before:content-['']",
+                )}
                 onClick={handlePostClick}
               >
-                {renderContent(post.content, fullPage)}
-              </p>
+                <p className="whitespace-pre-wrap break-words leading-relaxed">
+                  {renderContent(summary, fullPage)}
+                </p>
+              </div>
+            )}
+
+            {shouldShowFullContent && (
+              <div onClick={handlePostClick}>
+                <p className="text-foreground whitespace-pre-wrap break-words leading-relaxed">
+                  {renderContent(post.content, true)}
+                </p>
+              </div>
             )}
 
             <PostCodeSection

--- a/src/widgets/post-card/ui/post-code-section.tsx
+++ b/src/widgets/post-card/ui/post-code-section.tsx
@@ -67,7 +67,7 @@ export function PostCodeSection({
       <CodeViewer
         code={post.code}
         language={post.language || "text"}
-        readOnly={!fullPage || !post.is_review_enabled}
+        readOnly={!fullPage}
         renderSelectionComponent={(startLine, endLine) => (
           <CommentForm
             postId={post.id}

--- a/src/widgets/post-card/ui/post-header.tsx
+++ b/src/widgets/post-card/ui/post-header.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
 
-import { CodeXml } from "lucide-react";
+import { Bot, PencilLine } from "lucide-react";
 
 import { PostMenu } from "@/features/post-interaction";
 import { UserAvatar } from "@/entities/user";
+import { AUTHORING_MODE_LABELS } from "@/shared/lib";
 import { formatRelativeTime } from "@/shared/lib";
 import { Post } from "@/shared/types";
 import { Badge } from "@/shared/ui/badge";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 
 interface PostHeaderProps {
   post: Post;
@@ -40,19 +40,14 @@ export function PostHeader({ post }: PostHeaderProps) {
       </div>
 
       <div className="flex gap-2 items-center">
-        {post.is_review_enabled && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Badge variant="default">
-                <CodeXml className="w-4 h-4" />
-                Code Review
-              </Badge>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>코드 리뷰를 남길 수 있는 게시글입니다.</p>
-            </TooltipContent>
-          </Tooltip>
-        )}
+        <Badge variant="secondary">
+          {post.authoring_mode === "ai_assisted" ? (
+            <Bot className="w-4 h-4" />
+          ) : (
+            <PencilLine className="w-4 h-4" />
+          )}
+          {AUTHORING_MODE_LABELS[post.authoring_mode]}
+        </Badge>
         <PostMenu post={post} />
       </div>
     </div>

--- a/src/widgets/post-card/ui/use-post-interaction.test.ts
+++ b/src/widgets/post-card/ui/use-post-interaction.test.ts
@@ -88,16 +88,20 @@ describe("usePostInteraction", () => {
       await result.current.handleLikeClick();
     });
 
-    expect(result.current.isLiked).toBe(true);
-    expect(result.current.likeCount).toBe(4);
+    await waitFor(() => {
+      expect(result.current.isLiked).toBe(true);
+      expect(result.current.likeCount).toBe(4);
+    });
     expect(mockCreatePostLikeAction).toHaveBeenCalledWith(10);
 
     await act(async () => {
       await result.current.handleBookmarkClick();
     });
 
-    expect(result.current.isBookmarked).toBe(true);
-    expect(result.current.bookmarkCount).toBe(3);
+    await waitFor(() => {
+      expect(result.current.isBookmarked).toBe(true);
+      expect(result.current.bookmarkCount).toBe(3);
+    });
     expect(mockCreateBookmarkAction).toHaveBeenCalledWith(10);
   });
 
@@ -178,13 +182,21 @@ describe("usePostInteraction", () => {
 
     await act(async () => {
       await result.current.handleLikeClick();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLiked).toBe(true);
+      expect(result.current.likeCount).toBe(2);
+    });
+
+    await act(async () => {
       await result.current.handleBookmarkClick();
     });
 
-    expect(result.current.isLiked).toBe(true);
-    expect(result.current.likeCount).toBe(2);
-    expect(result.current.isBookmarked).toBe(true);
-    expect(result.current.bookmarkCount).toBe(5);
+    await waitFor(() => {
+      expect(result.current.isBookmarked).toBe(true);
+      expect(result.current.bookmarkCount).toBe(5);
+    });
 
     rerender({
       postId: 31,

--- a/src/widgets/post-card/ui/use-post-interaction.test.ts
+++ b/src/widgets/post-card/ui/use-post-interaction.test.ts
@@ -5,6 +5,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { usePostInteraction } from "./use-post-interaction";
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+}
+
 const {
   mockUseAuth,
   mockHandleAction,
@@ -122,6 +131,87 @@ describe("usePostInteraction", () => {
 
     expect(result.current.isLiked).toBe(false);
     expect(result.current.likeCount).toBe(7);
+  });
+
+  it("ignores stale like rollback after a newer toggle succeeds", async () => {
+    const firstLike = createDeferred<{ error: string | null }>();
+    const secondLike = createDeferred<{ error: string | null }>();
+    mockCreatePostLikeAction.mockReturnValueOnce(firstLike.promise);
+    mockDeletePostLikeAction.mockReturnValueOnce(secondLike.promise);
+
+    const { result } = renderHook(() =>
+      usePostInteraction({
+        postId: 15,
+        initialIsLiked: false,
+        initialLikeCount: 3,
+      }),
+    );
+
+    act(() => {
+      void result.current.handleLikeClick();
+    });
+
+    expect(result.current.isLiked).toBe(true);
+    expect(result.current.likeCount).toBe(4);
+
+    act(() => {
+      void result.current.handleLikeClick();
+    });
+
+    expect(result.current.isLiked).toBe(false);
+    expect(result.current.likeCount).toBe(3);
+
+    await act(async () => {
+      secondLike.resolve({ error: null });
+      await secondLike.promise;
+    });
+
+    await act(async () => {
+      firstLike.resolve({ error: "fail" });
+      await firstLike.promise;
+    });
+
+    expect(result.current.isLiked).toBe(false);
+    expect(result.current.likeCount).toBe(3);
+  });
+
+  it("rolls back only the like slice when bookmark state changes later", async () => {
+    const failedLike = createDeferred<{ error: string | null }>();
+    mockCreatePostLikeAction.mockReturnValueOnce(failedLike.promise);
+
+    const { result } = renderHook(() =>
+      usePostInteraction({
+        postId: 18,
+        initialIsLiked: false,
+        initialLikeCount: 1,
+        initialIsBookmarked: false,
+        initialBookmarkCount: 4,
+      }),
+    );
+
+    act(() => {
+      void result.current.handleLikeClick();
+    });
+
+    expect(result.current.isLiked).toBe(true);
+    expect(result.current.likeCount).toBe(2);
+
+    await act(async () => {
+      await result.current.handleBookmarkClick();
+    });
+
+    expect(result.current.isBookmarked).toBe(true);
+    expect(result.current.bookmarkCount).toBe(5);
+
+    await act(async () => {
+      failedLike.resolve({ error: "fail" });
+      await failedLike.promise;
+    });
+
+    expect(result.current.isLiked).toBe(false);
+    expect(result.current.likeCount).toBe(1);
+    expect(result.current.isBookmarked).toBe(true);
+    expect(result.current.bookmarkCount).toBe(5);
   });
 
   it("syncs local state when server props change", async () => {

--- a/src/widgets/post-card/ui/use-post-interaction.ts
+++ b/src/widgets/post-card/ui/use-post-interaction.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useReducer } from "react";
 
 import {
   createBookmarkAction,
@@ -19,6 +19,24 @@ interface UsePostInteractionProps {
   initialBookmarkCount?: number;
 }
 
+type InteractionState = {
+  isBookmarked: boolean;
+  isLiked: boolean;
+  bookmarkCount: number;
+  likeCount: number;
+};
+
+type InteractionAction =
+  | { type: "replace"; nextState: InteractionState }
+  | { type: "sync"; nextState: InteractionState };
+
+function interactionReducer(
+  _state: InteractionState,
+  action: InteractionAction,
+) {
+  return action.nextState;
+}
+
 export function usePostInteraction({
   postId,
   initialIsLiked = false,
@@ -27,24 +45,37 @@ export function usePostInteraction({
   initialBookmarkCount = 0,
 }: UsePostInteractionProps) {
   const { user, openAuthModal } = useAuth();
-  const [likedState, setLikedState] = useState(initialIsLiked);
-  const [bookmarkedState, setBookmarkedState] = useState(initialIsBookmarked);
-  const [likeCount, setLikeCount] = useState(initialLikeCount);
-  const [bookmarkCount, setBookmarkCount] = useState(initialBookmarkCount);
+  const [interactionState, dispatch] = useReducer(interactionReducer, {
+    isBookmarked: initialIsBookmarked,
+    isLiked: initialIsLiked,
+    bookmarkCount: initialBookmarkCount,
+    likeCount: initialLikeCount,
+  });
+  const {
+    isLiked: likedState,
+    isBookmarked: bookmarkedState,
+    likeCount,
+    bookmarkCount,
+  } = interactionState;
   const isLiked = user ? likedState : false;
   const isBookmarked = user ? bookmarkedState : false;
 
   useEffect(() => {
-    setLikedState(initialIsLiked);
-    setBookmarkedState(initialIsBookmarked);
-    setLikeCount(initialLikeCount);
-    setBookmarkCount(initialBookmarkCount);
+    dispatch({
+      type: "sync",
+      nextState: {
+        isBookmarked: initialIsBookmarked,
+        isLiked: initialIsLiked,
+        bookmarkCount: initialBookmarkCount,
+        likeCount: initialLikeCount,
+      },
+    });
   }, [
     postId,
-    initialIsLiked,
     initialIsBookmarked,
-    initialLikeCount,
+    initialIsLiked,
     initialBookmarkCount,
+    initialLikeCount,
   ]);
 
   const handleLikeClick = async () => {
@@ -55,20 +86,23 @@ export function usePostInteraction({
     }
 
     const willLike = !likedState;
-    const previousState = likedState;
-    const previousCount = likeCount;
-    setLikedState(willLike);
-    setLikeCount((prev) => (willLike ? prev + 1 : Math.max(0, prev - 1)));
+    const previousState = interactionState;
+    const nextState = {
+      isLiked: willLike,
+      isBookmarked: bookmarkedState,
+      likeCount: willLike ? likeCount + 1 : Math.max(0, likeCount - 1),
+      bookmarkCount,
+    };
 
     const action = willLike
       ? createPostLikeAction(postId)
       : deletePostLikeAction(postId);
 
+    dispatch({ type: "replace", nextState });
     await handleAction(action, {
       actionName: willLike ? "create_post_like" : "delete_post_like",
       onError: () => {
-        setLikedState(previousState);
-        setLikeCount(previousCount);
+        dispatch({ type: "replace", nextState: previousState });
       },
     });
   };
@@ -81,22 +115,25 @@ export function usePostInteraction({
     }
 
     const willBookmark = !bookmarkedState;
-    const previousState = bookmarkedState;
-    const previousCount = bookmarkCount;
-    setBookmarkedState(willBookmark);
-    setBookmarkCount((prev) =>
-      willBookmark ? prev + 1 : Math.max(0, prev - 1),
-    );
+    const previousState = interactionState;
+    const nextState = {
+      isBookmarked: willBookmark,
+      isLiked: likedState,
+      bookmarkCount: willBookmark
+        ? bookmarkCount + 1
+        : Math.max(0, bookmarkCount - 1),
+      likeCount,
+    };
 
     const action = willBookmark
       ? createBookmarkAction(postId)
       : deleteBookmarkAction(postId);
 
+    dispatch({ type: "replace", nextState });
     await handleAction(action, {
       actionName: willBookmark ? "create_bookmark" : "delete_bookmark",
       onError: () => {
-        setBookmarkedState(previousState);
-        setBookmarkCount(previousCount);
+        dispatch({ type: "replace", nextState: previousState });
       },
     });
   };

--- a/src/widgets/post-card/ui/use-post-interaction.ts
+++ b/src/widgets/post-card/ui/use-post-interaction.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useReducer } from "react";
+import { useEffect, useReducer, useRef } from "react";
 
 import {
   createBookmarkAction,
@@ -27,14 +27,77 @@ type InteractionState = {
 };
 
 type InteractionAction =
-  | { type: "replace"; nextState: InteractionState }
-  | { type: "sync"; nextState: InteractionState };
+  | { type: "sync"; nextState: InteractionState }
+  | { type: "toggle_like" }
+  | { type: "toggle_bookmark" }
+  | {
+      type: "rollback_like";
+      previousState: Pick<InteractionState, "isLiked" | "likeCount">;
+    }
+  | {
+      type: "rollback_bookmark";
+      previousState: Pick<InteractionState, "isBookmarked" | "bookmarkCount">;
+    };
+
+function createInteractionState({
+  initialIsLiked,
+  initialIsBookmarked,
+  initialLikeCount,
+  initialBookmarkCount,
+}: {
+  initialIsLiked: boolean;
+  initialIsBookmarked: boolean;
+  initialLikeCount: number;
+  initialBookmarkCount: number;
+}): InteractionState {
+  return {
+    isBookmarked: initialIsBookmarked,
+    isLiked: initialIsLiked,
+    bookmarkCount: initialBookmarkCount,
+    likeCount: initialLikeCount,
+  };
+}
 
 function interactionReducer(
-  _state: InteractionState,
+  state: InteractionState,
   action: InteractionAction,
-) {
-  return action.nextState;
+): InteractionState {
+  switch (action.type) {
+    case "sync":
+      return action.nextState;
+    case "toggle_like": {
+      const willLike = !state.isLiked;
+
+      return {
+        ...state,
+        isLiked: willLike,
+        likeCount: willLike ? state.likeCount + 1 : Math.max(0, state.likeCount - 1),
+      };
+    }
+    case "toggle_bookmark": {
+      const willBookmark = !state.isBookmarked;
+
+      return {
+        ...state,
+        isBookmarked: willBookmark,
+        bookmarkCount: willBookmark
+          ? state.bookmarkCount + 1
+          : Math.max(0, state.bookmarkCount - 1),
+      };
+    }
+    case "rollback_like":
+      return {
+        ...state,
+        isLiked: action.previousState.isLiked,
+        likeCount: action.previousState.likeCount,
+      };
+    case "rollback_bookmark":
+      return {
+        ...state,
+        isBookmarked: action.previousState.isBookmarked,
+        bookmarkCount: action.previousState.bookmarkCount,
+      };
+  }
 }
 
 export function usePostInteraction({
@@ -45,12 +108,17 @@ export function usePostInteraction({
   initialBookmarkCount = 0,
 }: UsePostInteractionProps) {
   const { user, openAuthModal } = useAuth();
-  const [interactionState, dispatch] = useReducer(interactionReducer, {
-    isBookmarked: initialIsBookmarked,
-    isLiked: initialIsLiked,
-    bookmarkCount: initialBookmarkCount,
-    likeCount: initialLikeCount,
-  });
+  const [interactionState, dispatch] = useReducer(
+    interactionReducer,
+    createInteractionState({
+      initialIsBookmarked,
+      initialIsLiked,
+      initialBookmarkCount,
+      initialLikeCount,
+    }),
+  );
+  const likeRequestIdRef = useRef(0);
+  const bookmarkRequestIdRef = useRef(0);
   const {
     isLiked: likedState,
     isBookmarked: bookmarkedState,
@@ -61,14 +129,16 @@ export function usePostInteraction({
   const isBookmarked = user ? bookmarkedState : false;
 
   useEffect(() => {
+    likeRequestIdRef.current += 1;
+    bookmarkRequestIdRef.current += 1;
     dispatch({
       type: "sync",
-      nextState: {
-        isBookmarked: initialIsBookmarked,
-        isLiked: initialIsLiked,
-        bookmarkCount: initialBookmarkCount,
-        likeCount: initialLikeCount,
-      },
+      nextState: createInteractionState({
+        initialIsBookmarked,
+        initialIsLiked,
+        initialBookmarkCount,
+        initialLikeCount,
+      }),
     });
   }, [
     postId,
@@ -85,24 +155,30 @@ export function usePostInteraction({
       return;
     }
 
-    const willLike = !likedState;
     const previousState = interactionState;
-    const nextState = {
-      isLiked: willLike,
-      isBookmarked: bookmarkedState,
-      likeCount: willLike ? likeCount + 1 : Math.max(0, likeCount - 1),
-      bookmarkCount,
-    };
+    const willLike = !previousState.isLiked;
+    const requestId = likeRequestIdRef.current + 1;
+    likeRequestIdRef.current = requestId;
 
     const action = willLike
       ? createPostLikeAction(postId)
       : deletePostLikeAction(postId);
 
-    dispatch({ type: "replace", nextState });
+    dispatch({ type: "toggle_like" });
     await handleAction(action, {
       actionName: willLike ? "create_post_like" : "delete_post_like",
       onError: () => {
-        dispatch({ type: "replace", nextState: previousState });
+        if (likeRequestIdRef.current !== requestId) {
+          return;
+        }
+
+        dispatch({
+          type: "rollback_like",
+          previousState: {
+            isLiked: previousState.isLiked,
+            likeCount: previousState.likeCount,
+          },
+        });
       },
     });
   };
@@ -114,26 +190,30 @@ export function usePostInteraction({
       return;
     }
 
-    const willBookmark = !bookmarkedState;
     const previousState = interactionState;
-    const nextState = {
-      isBookmarked: willBookmark,
-      isLiked: likedState,
-      bookmarkCount: willBookmark
-        ? bookmarkCount + 1
-        : Math.max(0, bookmarkCount - 1),
-      likeCount,
-    };
+    const willBookmark = !previousState.isBookmarked;
+    const requestId = bookmarkRequestIdRef.current + 1;
+    bookmarkRequestIdRef.current = requestId;
 
     const action = willBookmark
       ? createBookmarkAction(postId)
       : deleteBookmarkAction(postId);
 
-    dispatch({ type: "replace", nextState });
+    dispatch({ type: "toggle_bookmark" });
     await handleAction(action, {
       actionName: willBookmark ? "create_bookmark" : "delete_bookmark",
       onError: () => {
-        dispatch({ type: "replace", nextState: previousState });
+        if (bookmarkRequestIdRef.current !== requestId) {
+          return;
+        }
+
+        dispatch({
+          type: "rollback_bookmark",
+          previousState: {
+            isBookmarked: previousState.isBookmarked,
+            bookmarkCount: previousState.bookmarkCount,
+          },
+        });
       },
     });
   };

--- a/src/widgets/sidebar/ui/welcome-card.tsx
+++ b/src/widgets/sidebar/ui/welcome-card.tsx
@@ -23,7 +23,7 @@ export default function WelcomeCard() {
               <p className="text-foreground">CodeLog에 오신 것을 환영합니다!</p>
             </div>
             <p className="text-foreground">
-              지식을 공유하고, 리뷰를 받고, 함께 성장하세요.
+              오늘 배운 내용을 짧게 남기고, 함께 성장하세요.
             </p>
             <p className="text-muted-foreground text-sm">
               로그인하고 커뮤니티에 참여해보세요!

--- a/supabase/migrations/20260325100000_codelog_v2_core.sql
+++ b/supabase/migrations/20260325100000_codelog_v2_core.sql
@@ -1,0 +1,180 @@
+alter table public.posts
+  add column if not exists description text;
+
+alter table public.posts
+  add column if not exists authoring_mode text not null default 'hand_written';
+
+update public.posts
+set description = left(
+  coalesce(
+    nullif(btrim(regexp_replace(content, '\s+', ' ', 'g')), ''),
+    case
+      when code is not null and btrim(code) <> '' then '코드 스니펫을 기록했습니다.'
+      else '오늘 배운 내용을 기록했습니다.'
+    end
+  ),
+  200
+)
+where description is null
+   or btrim(description) = '';
+
+alter table public.posts
+  alter column description set not null;
+
+alter table public.posts
+  alter column description drop default;
+
+alter table public.posts
+  drop constraint if exists posts_authoring_mode_check;
+
+alter table public.posts
+  add constraint posts_authoring_mode_check
+  check (authoring_mode in ('hand_written', 'ai_assisted'));
+
+alter table public.posts
+  drop constraint if exists posts_description_length_check;
+
+alter table public.posts
+  add constraint posts_description_length_check
+  check (char_length(btrim(description)) between 1 and 200);
+
+create or replace function public.upsert_post_tags(p_post_id bigint, p_tags text[])
+returns void
+language plpgsql
+as $$
+declare
+  raw_tag_name text;
+  normalized_tag_name text;
+  resolved_tag_id bigint;
+begin
+  if p_tags is null or array_length(p_tags, 1) is null then
+    return;
+  end if;
+
+  foreach raw_tag_name in array p_tags loop
+    normalized_tag_name := btrim(raw_tag_name);
+    resolved_tag_id := null;
+
+    if normalized_tag_name = '' then
+      continue;
+    end if;
+
+    select id
+      into resolved_tag_id
+      from public.tags
+     where name = normalized_tag_name
+     limit 1;
+
+    if resolved_tag_id is null then
+      insert into public.tags (name)
+      values (normalized_tag_name)
+      returning id into resolved_tag_id;
+    end if;
+
+    if not exists (
+      select 1
+        from public.posttags
+       where post_id = p_post_id
+         and tag_id = resolved_tag_id
+    ) then
+      insert into public.posttags (post_id, tag_id)
+      values (p_post_id, resolved_tag_id);
+    end if;
+  end loop;
+end;
+$$;
+
+drop function if exists public.create_post_with_tags(json, text[]);
+drop function if exists public.create_post_with_tags(jsonb, text[]);
+
+create function public.create_post_with_tags(post_data json, tags text[])
+returns json
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  created_post public.posts;
+  post_payload jsonb := post_data::jsonb;
+begin
+  insert into public.posts (
+    user_id,
+    content,
+    description,
+    code,
+    language,
+    authoring_mode
+  )
+  values (
+    (post_payload ->> 'user_id')::uuid,
+    post_payload ->> 'content',
+    post_payload ->> 'description',
+    case
+      when post_payload ? 'code' then nullif(post_payload ->> 'code', '')
+      else null
+    end,
+    case
+      when post_payload ? 'language' then nullif(post_payload ->> 'language', '')
+      else null
+    end,
+    coalesce(nullif(post_payload ->> 'authoring_mode', ''), 'hand_written')
+  )
+  returning * into created_post;
+
+  perform public.upsert_post_tags(created_post.id, tags);
+
+  return to_json(created_post);
+end;
+$$;
+
+drop function if exists public.update_post_with_tags(bigint, json, text[]);
+drop function if exists public.update_post_with_tags(bigint, jsonb, text[]);
+
+create function public.update_post_with_tags(
+  p_post_id bigint,
+  post_data json,
+  tags text[]
+)
+returns json
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  updated_post public.posts;
+  post_payload jsonb := post_data::jsonb;
+begin
+  update public.posts
+     set content = coalesce(post_payload ->> 'content', content),
+         description = coalesce(post_payload ->> 'description', description),
+         code = case
+           when post_payload ? 'code' then nullif(post_payload ->> 'code', '')
+           else code
+         end,
+         language = case
+           when post_payload ? 'language' then nullif(post_payload ->> 'language', '')
+           else language
+         end,
+         authoring_mode = case
+           when post_payload ? 'authoring_mode'
+             then coalesce(nullif(post_payload ->> 'authoring_mode', ''), 'hand_written')
+           else authoring_mode
+         end,
+         updated_at = now()
+   where id = p_post_id
+     and deleted_at is null
+  returning * into updated_post;
+
+  if updated_post is null then
+    raise exception 'Post % not found or deleted', p_post_id;
+  end if;
+
+  delete from public.posttags where post_id = p_post_id;
+  perform public.upsert_post_tags(p_post_id, tags);
+
+  return to_json(updated_post);
+end;
+$$;
+
+alter table public.posts
+  drop column if exists is_review_enabled;


### PR DESCRIPTION
## 무엇을 바꿨는지
- 포스트 스키마와 RPC를 `description`·`authoring_mode` 중심으로 전환하고 `is_review_enabled`를 제거했습니다.
- 포스트 작성/수정, TODAY 노출, 카드/상세 인터랙션을 새 모델에 맞게 정리하고 인라인 코멘트 허용 흐름을 일원화했습니다.
- 하루 1글 제약, 요약 텍스트 노출, PostHog 계측 지점을 코드와 테스트에 함께 반영해 v2 포스트 흐름의 기반을 맞췄습니다.

## 왜 바꿨는지
- #77의 핵심 요구사항은 `content` 중심 게시글에서 `description` 중심 TIL 포스트 모델로 전환하는 것입니다.
- TODAY 피드, 공개 상세, 작성 다이얼로그가 서로 다른 필드를 바라보면 UI와 데이터가 쉽게 어긋나므로 DB, RPC, 서비스, 프런트 스키마를 한 번에 맞출 필요가 있었습니다.
- 코드 스니펫 코멘트도 `is_review_enabled` 토글 대신 기본 허용 정책으로 단순화해야 이후 Logan Bot, SEO, TODAY 기능이 같은 모델 위에서 이어집니다.

## 어떤 대안을 버렸는지
- 기존 `content`를 요약과 본문으로 겸용하는 방안은 카드와 상세 페이지의 역할이 계속 섞여 버려 버렸습니다.
- 프런트 validation만 추가하고 DB 스키마 변경을 미루는 방안은 RPC와 기존 데이터가 제약을 보장하지 못해 채택하지 않았습니다.
- `is_review_enabled` 플래그를 유지한 채 UI만 숨기는 방안은 정책과 데이터가 분리돼 유지보수 비용이 커져 버렸습니다.

## 테스트 결과
- `vitest run src/entities/post/api/post.action.test.ts src/entities/post/api/post.service.test.ts src/entities/comment/api/comment.service.test.ts src/widgets/post-card/ui/use-post-interaction.test.ts`
- 결과: 4개 파일, 22개 테스트 통과
- `eslint src/entities/post/api/post.action.ts src/entities/post/api/post.service.ts src/features/post-interaction/ui/post-dialog.tsx src/pages/home/ui/today-section.tsx src/pages/today/ui/today.tsx src/widgets/post-card/ui/post-card.tsx`
- 결과: 통과
- 수동 검증: 미실시 (사유: PR 생성 작업 범위라 자동 검증만 우선 수행)

## 영향 범위
- 포스트 생성/수정 액션, TODAY 섹션과 TODAY 페이지, 포스트 카드/헤더/코드 섹션 UI에 영향을 줍니다.
- `posts` 테이블과 `create_post_with_tags` / `update_post_with_tags` RPC 시그니처 및 제약 조건이 변경됩니다.
- PostHog 이벤트 속성, 검색/리스트 쿼리, 인라인 코멘트 허용 정책이 새 포스트 모델을 기준으로 동작합니다.

## 리뷰가 필요한 요소
- [ ] `20260325100000_codelog_v2_core.sql`의 `description` 백필과 `authoring_mode` 제약이 운영 데이터에 안전하게 적용되는지 확인 부탁드립니다.
- [ ] TODAY 섹션과 포스트 카드가 `description`을 우선 노출하도록 바뀐 뒤, 기존 게시글 fallback이 의도대로 동작하는지 확인 부탁드립니다.
- [ ] `is_review_enabled` 제거 후 코드 스니펫 인라인 코멘트가 기존 상세/댓글 흐름과 충돌하지 않는지 확인 부탁드립니다.

 #77

